### PR TITLE
Adding external account reference to the query string

### DIFF
--- a/AssistedRateSpecTest.py
+++ b/AssistedRateSpecTest.py
@@ -331,6 +331,7 @@ def _get_request(query_parameters):
 
     query_string = QUERY_STRING_FORMAT.format(
         guests=query_parameters.guests,
+        external_account_reference=query_parameters.external_account_reference,
         external_listing_reference=query_parameters.external_listing_reference,
         arrival=query_parameters.arrival,
         departure=query_parameters.departure,


### PR DESCRIPTION
When testing assisted rates the external account reference needs to be passed.